### PR TITLE
feat: apply chunking to text2voice conversion and improve UI feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
 import gradio as gr
 import os
 import soundfile as sf
-from kanade_tokenizer import load_audio
 from core.cloner import KokoClone
-from core.chunked_convert import chunked_voice_conversion
 
 # 1. Initialize the cloner globally so models load only once when the server starts
 print("Loading KokoClone models for the Web UI...")
@@ -39,19 +37,11 @@ def convert_voice(source_audio_path, ref_audio_path):
     output_file = "gradio_convert_output.wav"
 
     try:
-        # Load both audio files onto the same device as the Kanade model
-        source_wav = load_audio(source_audio_path, sample_rate=cloner.sample_rate).to(cloner.device)
-        ref_wav = load_audio(ref_audio_path, sample_rate=cloner.sample_rate).to(cloner.device)
-
-        converted = chunked_voice_conversion(
-            kanade=cloner.kanade,
-            vocoder_model=cloner.vocoder,
-            source_wav=source_wav,
-            ref_wav=ref_wav,
-            sample_rate=cloner.sample_rate,
+        cloner.convert(
+            source_audio=source_audio_path,
+            reference_audio=ref_audio_path,
+            output_path=output_file
         )
-
-        sf.write(output_file, converted.numpy(), cloner.sample_rate)
         return output_file
     except Exception as e:
         raise gr.Error(f"An error occurred during conversion: {str(e)}")
@@ -122,9 +112,15 @@ with gr.Blocks() as demo:
                     )
 
             submit_btn.click(
+                fn=lambda: gr.update(value="⌛ Generating...", interactive=False),
+                outputs=submit_btn
+            ).then(
                 fn=clone_voice,
                 inputs=[text_input, lang_input, ref_audio_input],
                 outputs=output_audio
+            ).then(
+                fn=lambda: gr.update(value="🚀 Generate Clone", interactive=True),
+                outputs=submit_btn
             )
 
         # ── Tab 2: Audio → Re-voiced Speech ─────────────────────────────────
@@ -166,9 +162,15 @@ with gr.Blocks() as demo:
                     )
 
             convert_btn.click(
+                fn=lambda: gr.update(value="⌛ Converting...", interactive=False),
+                outputs=convert_btn
+            ).then(
                 fn=convert_voice,
                 inputs=[source_audio_input, ref_audio_convert_input],
                 outputs=convert_output_audio
+            ).then(
+                fn=lambda: gr.update(value="🔁 Convert Voice", interactive=True),
+                outputs=convert_btn
             )
 
 # 4. Launch the app

--- a/cli.py
+++ b/cli.py
@@ -1,9 +1,6 @@
 import argparse
 import sys
-import soundfile as sf
-from kanade_tokenizer import load_audio
 from core.cloner import KokoClone
-from core.chunked_convert import chunked_voice_conversion
 
 
 def main() -> None:
@@ -49,19 +46,11 @@ def main() -> None:
             parser.error("--source is required when --mode is 'convert'")
 
         try:
-            source_wav = load_audio(args.source, sample_rate=cloner.sample_rate).to(cloner.device)
-            ref_wav = load_audio(args.ref, sample_rate=cloner.sample_rate).to(cloner.device)
-
-            converted = chunked_voice_conversion(
-                kanade=cloner.kanade,
-                vocoder_model=cloner.vocoder,
-                source_wav=source_wav,
-                ref_wav=ref_wav,
-                sample_rate=cloner.sample_rate,
+            cloner.convert(
+                source_audio=args.source,
+                reference_audio=args.ref,
+                output_path=args.out,
             )
-
-            sf.write(args.out, converted.numpy(), cloner.sample_rate)
-            print(f"Success! Saved: {args.out}")
         except Exception as exc:
             print(f"Error during voice conversion: {exc}", file=sys.stderr)
             sys.exit(1)

--- a/core/cloner.py
+++ b/core/cloner.py
@@ -7,6 +7,7 @@ from kanade_tokenizer import KanadeModel, load_audio, load_vocoder, vocode
 from kokoro_onnx import Kokoro
 from misaki import espeak
 from misaki.espeak import EspeakG2P
+from core.chunked_convert import chunked_voice_conversion
 
 class KokoClone:
     def __init__(self, kanade_model="frothywater/kanade-12.5hz", hf_repo="PatnaikAshish/kokoclone"):
@@ -119,12 +120,36 @@ class KokoClone:
             ref_wav = load_audio(reference_audio, sample_rate=self.sample_rate).to(self.device)
 
             with torch.inference_mode():
-                converted_mel = self.kanade.voice_conversion(source_waveform=source_wav, reference_waveform=ref_wav)
-                converted_wav = vocode(self.vocoder, converted_mel.unsqueeze(0))
+                converted_wav = chunked_voice_conversion(
+                    kanade=self.kanade,
+                    vocoder_model=self.vocoder,
+                    source_wav=source_wav,
+                    ref_wav=ref_wav,
+                    sample_rate=self.sample_rate
+                )
 
-            sf.write(output_path, converted_wav.squeeze().cpu().numpy(), self.sample_rate)
+            sf.write(output_path, converted_wav.numpy(), self.sample_rate)
             print(f"Success! Saved: {output_path}")
 
         finally:
             if os.path.exists(temp_path):
                 os.remove(temp_path) # Clean up temp file silently
+
+    def convert(self, source_audio, reference_audio, output_path="output.wav"):
+        """Re-voices source_audio to sound like reference_audio using chunking."""
+        print("Applying Voice Conversion...")
+        # Load and push to device
+        source_wav = load_audio(source_audio, sample_rate=self.sample_rate).to(self.device)
+        ref_wav = load_audio(reference_audio, sample_rate=self.sample_rate).to(self.device)
+
+        with torch.inference_mode():
+            converted_wav = chunked_voice_conversion(
+                kanade=self.kanade,
+                vocoder_model=self.vocoder,
+                source_wav=source_wav,
+                ref_wav=ref_wav,
+                sample_rate=self.sample_rate
+            )
+
+        sf.write(output_path, converted_wav.numpy(), self.sample_rate)
+        print(f"Success! Saved: {output_path}")


### PR DESCRIPTION
This PR applies the chunking logic used in voice2voice conversion to text2voice conversion in KokoClone.

Key changes:
- Updated KokoClone.generate to use chunked_voice_conversion, preventing OOM on long text syntheses.
- Centralized voice conversion logic into KokoClone.convert.
- Updated Web UI (app.py) and CLI (cli.py) to use these centralized methods.
- Added visual feedback (loading state and disabled buttons) to the Web UI during synthesis and conversion.